### PR TITLE
Restrict admin dashboard access to allowlisted emails

### DIFF
--- a/API/payment.ts
+++ b/API/payment.ts
@@ -18,7 +18,7 @@ export interface PaymentData {
 export const getPayment = async (paymentData: PaymentData) => {
   try {
     const response = await axiosInstance.post("/get-payment", paymentData);
-    console.log("payment response",response.data);
+    // console.log("payment response",response.data);
     return response.data;
   } catch (error: any) {
     throw {

--- a/app/(root)/submissions/page.tsx
+++ b/app/(root)/submissions/page.tsx
@@ -71,7 +71,7 @@ const SubmissionsPage = () => {
         10,
         filters
       );
-      console.log("📊 Response:", response);
+      // console.log("📊 Response:", response);
 
       if (response.success) {
         const newSubmissions = response.data.submissions;

--- a/app/admin/administrator/page.tsx
+++ b/app/admin/administrator/page.tsx
@@ -65,11 +65,11 @@ const Page = () => {
     }
   }, [dispatch, allUsers, status]);
 
-  console.log({allUsers})
+  // console.log({allUsers})
 
   const regularUsers = allUsers.filter((user) => user.role === "admin");
 
-  console.log({regularUsers})
+  // console.log({regularUsers})
 
 
   // useEffect(() => {

--- a/app/admin/challenges/page.tsx
+++ b/app/admin/challenges/page.tsx
@@ -143,7 +143,7 @@ const Page = () => {
     try {
       const res = await getAllChallenges();
 
-      console.log(res?.data);
+      // console.log(res?.data);
       const formattedData = res?.data?.map((item: any) => ({
         id: item?._id,
         title: item?.title,

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -17,6 +17,7 @@ import { getAllPlans } from "@/API/plan";
 import { getAllUsers } from "@/API/user";
 import Loading from "@/components/Loading";
 import { useRouter } from "next/navigation";
+import { useAdminAccess } from "@/hooks/useAdminAccess";
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -95,6 +96,8 @@ interface DashboardData {
 }
 
 export default function Page() {
+  const router = useRouter();
+  const { isPrivilegedAdmin, isLoaded } = useAdminAccess();
   const [dashboardData, setDashboardData] = useState<DashboardData | null>(null);
   const [paymentData, setPaymentData] = useState<any>(null);
   const [allPayments, setAllPayments] = useState<any[]>([]);
@@ -104,6 +107,11 @@ export default function Page() {
   const [allUsers, setAllUsers] = useState<any[]>([]);
 
   useEffect(() => {
+    if (!isLoaded) return;
+    if (!isPrivilegedAdmin) {
+      router.replace("/admin/challenges");
+      return;
+    }
     const fetchDashboardData = async () => {
       try {
         setLoading(true);
@@ -117,7 +125,6 @@ export default function Page() {
           name: user?.name,
           createdAt: user?.createdAt,
         }));
-        // console.log({response4});
         setDashboardData(response.data);
         setPaymentData(response2.data);
         setAllPayments(response3.data);
@@ -131,7 +138,11 @@ export default function Page() {
     };
 
     fetchDashboardData();
-  }, []);
+  }, [isLoaded, isPrivilegedAdmin, router]);
+
+  if (!isLoaded || !isPrivilegedAdmin) {
+    return <Loading />;
+  }
 
   // Process payment data to get subscription statistics
   const getSubscriptionStats = () => {

--- a/app/admin/plan-billing/page.tsx
+++ b/app/admin/plan-billing/page.tsx
@@ -36,7 +36,7 @@ const PlanBillingPage = () => {
   const { plans, status: planStatus } = useAppSelector((state: RootState) => state.plan);
   const { coupons, status: couponsStatus } = useAppSelector((state: RootState) => state.coupon);
 
-  console.log('plans', plans);
+  // console.log('plans', plans);
 
   
   const [activeTab, setActiveTab] = useState<

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -61,7 +61,7 @@ const Page = () => {
         id: plan._id,
         name: plan.name,
       }));
-      console.log({formattedData});
+      // console.log({formattedData});
       setPlans(formattedData);
     }
     getPlans();
@@ -71,7 +71,7 @@ const Page = () => {
 
   //  console.log(allUsers);
 
-  console.log(allUsers);
+  // console.log(allUsers);
 
   // Filter and sort users
   const filteredUsers = formatUserData(allUsers)
@@ -127,7 +127,7 @@ const Page = () => {
 
     const planOptions = plans.map((plan ) => plan.name);
   const subscriptionOptions = ["All", ...planOptions];
-  console.log({subscriptionOptions});
+  // console.log({subscriptionOptions});
 
   if (loading) {
     return <Loading />;

--- a/components/adminDashboard/Sidebar.tsx
+++ b/components/adminDashboard/Sidebar.tsx
@@ -14,11 +14,12 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useAdminAccess } from "@/hooks/useAdminAccess";
 // import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 // import { Button } from "../ui/button";
 
 const navItems = [
-  { icon: LayoutDashboard, label: "Dashboard", href: "/admin" },
+  { icon: LayoutDashboard, label: "Dashboard", href: "/admin", restricted: true },
   // { icon: ChartNoAxesCombined, label: "Analytics", href: "/admin/analytics" },
   { icon: CodeXml, label: "Challenges", href: "/admin/challenges" },
   { icon: ShieldPlus, label: "Administrator", href: "/admin/administrator" },
@@ -29,6 +30,10 @@ const navItems = [
 export const Sidebar = () => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const pathname = usePathname();
+  const { isPrivilegedAdmin } = useAdminAccess();
+  const visibleNavItems = navItems.filter(
+    (item) => !item.restricted || isPrivilegedAdmin
+  );
 
   // Function to check if the current path matches or is a subpath of a nav item
   const isActiveRoute = (href: string) => {
@@ -69,7 +74,7 @@ export const Sidebar = () => {
 
         {/* Navigation Items */}
         <nav className="p-2">
-          {navItems.map((item) => (
+          {visibleNavItems.map((item) => (
             <Link
               key={item.label}
               href={item.href}

--- a/components/adminDashboard/administrators/AdminDetails.tsx
+++ b/components/adminDashboard/administrators/AdminDetails.tsx
@@ -138,7 +138,7 @@ const AdminDetails = ({ id }: { id: string }) => {
     try {
       const result = await dispatch(modifyUser({ userId: user._id, userData: formData }));
       if (modifyUser.fulfilled.match(result)) {
-        console.log("User updated successfully!"); 
+        // console.log("User updated successfully!"); 
         router.back();
       } else {
         throw result.payload;

--- a/components/adminDashboard/administrators/AdministratorForm.tsx
+++ b/components/adminDashboard/administrators/AdministratorForm.tsx
@@ -53,7 +53,7 @@ const AdminForm = () => {
   const onSubmit = async (data: FormData) => {
     try {
       await registerAdmin(data)
-      console.log("Form submitted:", data);
+      // console.log("Form submitted:", data);
      toast.success("Form submitted successfully!");
      router.push("/admin/administrator")
       reset();

--- a/components/adminDashboard/challenges/EditChallenge.tsx
+++ b/components/adminDashboard/challenges/EditChallenge.tsx
@@ -24,7 +24,7 @@ const EditChallenge = () => {
     const id = searchParams.get('id');
     const router = useRouter();
 
-    console.log("id", id);
+    // console.log("id", id);
 
     const handleViewChallenge = () => {
         router.push(`/admin/challenges/view?id=${id}`);

--- a/components/adminDashboard/challenges/EditChallengeForm.tsx
+++ b/components/adminDashboard/challenges/EditChallengeForm.tsx
@@ -260,7 +260,7 @@ const EditChallengeForm = ({ challengeId }: EditChallengeFormProps) => {
       try {
         setLoading(true);
         const res = await getChallengeById(challengeId);
-        console.log({res});
+        // console.log({res});
         
         if (res?.data) {
           const challenge = res?.data;
@@ -336,14 +336,14 @@ const EditChallengeForm = ({ challengeId }: EditChallengeFormProps) => {
       setLoading(true);
       
       // Log form values for debugging
-      console.log('Form values:', {
-        ...values,
-        files: values.files?.map(f => ({
-          name: f.name,
-          contentLength: f.content.length,
-          size: f.size
-        }))
-      });
+      // console.log('Form values:', {
+      //   ...values,
+      //   files: values.files?.map(f => ({
+      //     name: f.name,
+      //     contentLength: f.content.length,
+      //     size: f.size
+      //   }))
+      // });
 
       // Clean up the data before sending to backend
       const cleanedValues = { ...values };
@@ -354,7 +354,7 @@ const EditChallengeForm = ({ challengeId }: EditChallengeFormProps) => {
       }
 
       const res = await updateChallenge(challengeId, cleanedValues)
-      console.log({res})
+      // console.log({res})
       
       if (res) {
         toast.success("Challenge updated successfully")
@@ -718,10 +718,10 @@ const EditChallengeForm = ({ challengeId }: EditChallengeFormProps) => {
                           const currentFiles = field.value || [];
                           field.onChange([...currentFiles, ...processedFiles]);
 
-                          console.log(
-                            'Processed files:',
-                            processedFiles.map(f => ({ name: f.name, size: f.size, contentLength: f.content.length }))
-                          );
+                          // console.log(
+                          //   'Processed files:',
+                          //   processedFiles.map(f => ({ name: f.name, size: f.size, contentLength: f.content.length }))
+                          // );
                         } catch (error) {
                           console.error('Error processing files:', error);
                           toast.error('Error processing files');

--- a/components/adminDashboard/challenges/ViewChallenges.tsx
+++ b/components/adminDashboard/challenges/ViewChallenges.tsx
@@ -59,7 +59,7 @@ const ViewChallenges = () => {
       try {
         setLoading(true);
         const res = await getChallengeById(String(id));
-        console.log({res});
+        // console.log({res});
         
         if (res) {
           setChallenge(res?.data);

--- a/components/adminDashboard/plan&Billing/CouponForm.tsx
+++ b/components/adminDashboard/plan&Billing/CouponForm.tsx
@@ -101,7 +101,7 @@ const CouponFormContent = () => {
     dispatch(registerCoupon(formData))
       .unwrap()
       .then(() => {
-        console.log("Coupon added successfully!");
+        // console.log("Coupon added successfully!");
         handleCancel()
       })
       .catch((err: any) => {

--- a/components/adminDashboard/plan&Billing/EditCoupon.tsx
+++ b/components/adminDashboard/plan&Billing/EditCoupon.tsx
@@ -98,7 +98,7 @@ const UpdateCouponForm = ({ initialData }: UpdateCouponFormProps) => {
     dispatch(modifyCoupon({ id: _id!, data: transformedData }))
       .unwrap()
       .then((res) => {
-        console.log("Coupon updated successfully:", res);
+        // console.log("Coupon updated successfully:", res);
         router.back();
       })
       .catch((error) => {

--- a/components/adminDashboard/plan&Billing/EditPlan.tsx
+++ b/components/adminDashboard/plan&Billing/EditPlan.tsx
@@ -122,7 +122,7 @@ const EditPlanForm = ({ initialData }: EditPlanFormProps) => {
     dispatch(modifyPlan({ id: _id!, data: transformedData }))
       .unwrap()
       .then((res) => {
-        console.log("Plan updated successfully:", res);
+        // console.log("Plan updated successfully:", res);
         router.back();
       })
       .catch((error) => {

--- a/components/adminDashboard/plan&Billing/PlanForm.tsx
+++ b/components/adminDashboard/plan&Billing/PlanForm.tsx
@@ -135,7 +135,7 @@ const PlanForm = () => {
     dispatch(registerPlan(transformedData))
       .unwrap()
       .then((res) => {
-        console.log("Plan registered successfully:", res);
+        // console.log("Plan registered successfully:", res);
         clearForm()
       })
       .catch((error) => {

--- a/components/adminDashboard/plan&Billing/TransactionsTable.tsx
+++ b/components/adminDashboard/plan&Billing/TransactionsTable.tsx
@@ -46,7 +46,7 @@ const TransactionsTable = () => {
     const fetchTransactions = async () => {
       try {
         const response = await getAllPayments();
-        console.log("response",response);
+        // console.log("response",response);
         const formattedTransactions = response.data.map((transaction: any) => ({
           paymentId: transaction.txnId,
           paidBy: transaction.customerName,
@@ -57,7 +57,7 @@ const TransactionsTable = () => {
           coupon: transaction.couponId?.code,
           plan: transaction.planId?.name,
         }));
-        console.log("formattedTransactions",formattedTransactions);
+        // console.log("formattedTransactions",formattedTransactions);
         setTransactions(formattedTransactions);
         
       } catch (error) {

--- a/components/billing/CheckoutModal.tsx
+++ b/components/billing/CheckoutModal.tsx
@@ -71,7 +71,7 @@ const CheckoutModal = ({ isOpen, onClose, plan }: CheckoutModalProps) => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('Form Data:', { ...formData, promoCode });
+    console.log('Form Data:');
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/billing/CheckoutPage.tsx
+++ b/components/billing/CheckoutPage.tsx
@@ -66,7 +66,7 @@ export const CheckoutPage = ({ plan, onClose, onSuccess, challengeId }: Checkout
       console.error('Error fetching coupons:', error);
     }
   };
-  console.log("coupons",coupons);
+  // console.log("coupons",coupons);
 
 
   const applyCoupon = async () => {
@@ -116,7 +116,7 @@ export const CheckoutPage = ({ plan, onClose, onSuccess, challengeId }: Checkout
 
   const handleCheckout = async () => {
     setIsProcessing(true);
-    console.log("challengeId", challengeId);
+    // console.log("challengeId", challengeId);
     try {
       const response = await getPayment({
         amount: finalPrice,

--- a/components/home/ChallengeCard.tsx
+++ b/components/home/ChallengeCard.tsx
@@ -81,9 +81,9 @@ const ChallengeCard = memo(({ title, difficulty, submissions, id, paymentMode, p
     };
 
     const handleCheckoutSuccess = (form: string) => {
-        console.log("handleCheckoutSuccess");
+        // console.log("handleCheckoutSuccess");
 
-        console.log("handleCheckoutSuccess");
+        // console.log("handleCheckoutSuccess");
         // console.log("form", form);
         setForm(form);
         setIsCheckoutOpen(false);

--- a/components/home/ChallengeList.tsx
+++ b/components/home/ChallengeList.tsx
@@ -51,7 +51,7 @@ const ChallengeList = ({ challenges, loading }: { challenges: ChallengeData[], l
     const fetchUserSubscriptions = async () => {
         try {
             const userSubscriptions = await getUserPaymentHistory(userId || "");
-            console.log("userSubscriptions", userSubscriptions?.data);
+            // console.log("userSubscriptions", userSubscriptions?.data);
             
             // Filter for successful subscriptions with non-Per Challenge plans
             const subscribedChallenges = userSubscriptions?.data?.filter(
@@ -61,7 +61,7 @@ const ChallengeList = ({ challenges, loading }: { challenges: ChallengeData[], l
                 subscription.planId?.priceMode !== "Per Challenge"
             ) || [];
             
-            console.log("subscribedChallenges", subscribedChallenges);
+            // console.log("subscribedChallenges", subscribedChallenges);
 
             if (subscribedChallenges.length > 0) {
                 // Get the latest subscription based on paymentCompletedAt
@@ -71,15 +71,15 @@ const ChallengeList = ({ challenges, loading }: { challenges: ChallengeData[], l
                     return currentDate > latestDate ? current : latest;
                 });
 
-                console.log("latestSubscription", latestSubscription);
+                // console.log("latestSubscription", latestSubscription);
 
                 // Check if the plan's endDate is after today's date
                 const today = new Date();
                 const planEndDate = new Date(latestSubscription.planId?.endDate);
                 
-                console.log("today:", today);
-                console.log("planEndDate:", planEndDate);
-                console.log("isActive:", planEndDate >= today);
+                // console.log("today:", today);
+                // console.log("planEndDate:", planEndDate);
+                // console.log("isActive:", planEndDate >= today);
 
                 // Set subscription status based on plan end date
                 setHasSubscribed(planEndDate >= today);

--- a/components/home/Challenges.tsx
+++ b/components/home/Challenges.tsx
@@ -182,13 +182,13 @@ const Challenges = () => {
 
         createUser(userData)
           .then((response) => {
-            console.log("Response:", response);
+            // console.log("Response:", response);
             if (response?.token) {
               setToken(response?.token);
               setCurrentUserId(response?.user?._id);
             }
             router.push("/");
-            console.log("User created successfully");
+            // console.log("User created successfully");
             toast.success("User created successfully");
             dispatch(fetchUsers());
           })
@@ -200,7 +200,7 @@ const Challenges = () => {
 
         loginUser(userEmail || '')
           .then((response) => {
-            console.log("Response:", response);
+            // console.log("Response:", response);
             if (response?.token) {
               setToken(response?.token);
               setCurrentUserId(response?.user?._id);
@@ -210,11 +210,11 @@ const Challenges = () => {
             console.error('Error creating user:', error);
             toast.error('Failed to create user');
           });
-        console.log("User already exists");
+        // console.log("User already exists");
       } else if (userExists) {
         loginUser(userEmail || '')
           .then((response) => {
-            console.log("Response:", response);
+            // console.log("Response:", response);
             if (response?.token) {
               setToken(response?.token);
               setCurrentUserId(response?.user?._id);
@@ -224,7 +224,7 @@ const Challenges = () => {
             console.error('Error creating user:', error);
             toast.error('Failed to create user');
           });
-        console.log("User already exists");
+        // console.log("User already exists");
       }
     }
   }, [isSignedIn, user, allUsers, dispatch, router, token]);

--- a/components/home/code/LogsTab.tsx
+++ b/components/home/code/LogsTab.tsx
@@ -57,13 +57,13 @@ const LogsTab = ({ sessionId, isConnected = false }: LogsTabProps) => {
         socketRef.current = socket;
 
         socket.on('connect', () => {
-          console.log('🔌 Connected to Socket.IO server');
+          // console.log('🔌 Connected to Socket.IO server');
           setIsSocketConnected(true);
           socket.emit('join-session', sessionId);
         });
 
         socket.on('disconnect', () => {
-          console.log('🔌 Disconnected from Socket.IO server');
+          // console.log('🔌 Disconnected from Socket.IO server');
           setIsSocketConnected(false);
         });
 

--- a/components/profile/ProfileSidebar.tsx
+++ b/components/profile/ProfileSidebar.tsx
@@ -23,7 +23,7 @@ const ProfileSidebar = ({ organizedData, UserName, Useravatar }: { organizedData
   const name = UserName || 'User';
   const avatar = Useravatar || 'https://github.com/shadcn.png';
 
-  console.log('📊 User:', name, avatar);
+  // console.log('📊 User:', name, avatar);
 
   const [showAll, setShowAll] = useState({
     easy: false,

--- a/components/profile/ProfileStats.tsx
+++ b/components/profile/ProfileStats.tsx
@@ -77,7 +77,7 @@ const ProfileStats = ({ organizedData, plan }: { organizedData: any, plan: any }
   const planEndDate = new Date(currentPlan?.endDate);
   const isActive = planEndDate >= today;
 
-  console.log('📊 Current Plan:', currentPlan);
+  // console.log('📊 Current Plan:', currentPlan);
 
   // Calculate stats from organized data
   const stats = organizedData ? {

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -10,6 +10,7 @@ import NotificationDropdown from "./NotificationDropdown";
 // import { auth } from '@clerk/nextjs/server';
 import { useAuth, UserButton, useUser } from '@clerk/nextjs';
 import { useCheckRole } from '@/hooks/useCheckRole';
+import { useAdminAccess } from '@/hooks/useAdminAccess';
 import { getCurrentUserId } from '@/config/token';
 
 export default function Navbar() {
@@ -25,9 +26,11 @@ export default function Navbar() {
     const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
     const [mounted, setMounted] = useState(false);
     const { checkUserRole } = useCheckRole();
+    const { isPrivilegedAdmin } = useAdminAccess();
 
-    
+
      const role = checkUserRole();
+     const dashboardHref = isPrivilegedAdmin ? '/admin' : '/admin/challenges';
   
 
     const { userId } = useAuth();
@@ -139,7 +142,7 @@ export default function Navbar() {
                         </Link>
                     </motion.div>
                     {role === 'admin' && !pathname.startsWith('/admin') && (
-                        <Link href="/admin" className=" rounded-lg px-4 py-2 bg-purple-600 text-white hover:bg-purple-700 transition-all duration-200 font-medium shadow-sm hover:shadow-md">
+                        <Link href={dashboardHref} className=" rounded-lg px-4 py-2 bg-purple-600 text-white hover:bg-purple-700 transition-all duration-200 font-medium shadow-sm hover:shadow-md">
                              Dashboard
                         </Link>
                     )}
@@ -267,7 +270,7 @@ export default function Navbar() {
                                         </div>
                                     </Link> */}
                                     {role === 'admin' && !pathname.startsWith('/admin') && (
-                        <Link href="/admin" className=" rounded-lg text-center  px-2 py-2 bg-purple-600 text-white hover:bg-purple-700 transition-all duration-200 font-medium shadow-sm hover:shadow-md">
+                        <Link href={dashboardHref} className=" rounded-lg text-center  px-2 py-2 bg-purple-600 text-white hover:bg-purple-700 transition-all duration-200 font-medium shadow-sm hover:shadow-md">
                              Dashboard
                         </Link>
                     )}

--- a/hooks/useAdminAccess.ts
+++ b/hooks/useAdminAccess.ts
@@ -1,0 +1,14 @@
+import { useUser } from "@clerk/nextjs";
+import { useCheckRole } from "./useCheckRole";
+import { isEmailAllowed } from "@/lib/access";
+
+export const useAdminAccess = () => {
+  const { user, isLoaded } = useUser();
+  const { checkUserRole } = useCheckRole();
+  const email =
+    user?.primaryEmailAddress?.emailAddress ??
+    user?.emailAddresses?.[0]?.emailAddress;
+  const isAdmin = checkUserRole() === "admin";
+  const isPrivilegedAdmin = isAdmin && isEmailAllowed(email);
+  return { isAdmin, isPrivilegedAdmin, isLoaded };
+};

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -1,0 +1,8 @@
+export const getAllowedEmails = (): string[] =>
+  (process.env.NEXT_PUBLIC_EMAILS ?? "")
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+
+export const isEmailAllowed = (email?: string | null) =>
+  !!email && getAllowedEmails().includes(email.toLowerCase());


### PR DESCRIPTION
Hide the Dashboard sidebar tab and gate /admin page access behind both role=admin and an email in NEXT_PUBLIC_EMAILS. Non-privileged admins are redirected to /admin/challenges, and the Navbar Dashboard button routes them there as well.